### PR TITLE
Changing overriding location with current location

### DIFF
--- a/widget.js
+++ b/widget.js
@@ -61,13 +61,25 @@ const performanceDebugger = new PerformanceDebugger();
  * 2. JSON file "./storage/scriptname.json"
  * 3. Hard-coded parameters right here:
  */
+
+ // Get user's current latitude and longitude
+ const getCurrentLocation = async() => {
+ 	await Location.setAccuracyToHundredMeters();
+ 	return Location.current().then((res) => {
+ 		return {
+ 			'latitude': res.latitude,
+ 			'longitude': res.longitude
+ 		};
+ 	}, err => log(err));
+ };
+
 const scriptParams = {
 	apiKey: 'XXX',
 	forceWidgetView: false,
 	writeLogsIfException: false,
 	logPerformanceMetrics: false,
-	overrideLatitude: 42.3549970,
-	overrideLongitude: -71.0644556
+	overrideLatitude: getCurrentLocation.latitude,
+	overrideLongitude: getCurrentLocation.longitude
 }
 
 const widgetParams = args.widgetParameter ? JSON.parse(args.widgetParameter) : undefined;
@@ -89,16 +101,7 @@ const refreshInterval = 6;
  ****** UTILITY FUNCTIONS ******
  *******************************/
 
-// Get user's current latitude and longitude
-const getCurrentLocation = async() => {
-	await Location.setAccuracyToHundredMeters();
-	return Location.current().then((res) => {
-		return {
-			'latitude': res.latitude,
-			'longitude': res.longitude
-		};
-	}, err => log(err));
-};
+
 
 /*
  * Given coordinates, return a description of the current location in words (town name, etc.).

--- a/widget.js
+++ b/widget.js
@@ -317,6 +317,25 @@ const createTable = (map, items) => {
 		table.addRow(row);
 		label = nextChar(label);
 	});
+  //adding one more item for Nearby
+  logger.log('ITEM');
+	const row = new UITableRow();
+	const markerUrl = `http://google.com`;
+	const imageUrl = 'https://cdn-icons-png.flaticon.com/512/48/48927.png';
+	const title = 'See more nearby';
+	const markerCell = row.addButton(label);
+	const imageCell = row.addImageAtURL(imageUrl);
+	const titleCell = row.addText(title);
+	markerCell.onTap = () => Safari.open(getCoordsUrl({ latitude: item.lat, longitude: item.lng }));
+	markerCell.widthWeight = 10;
+	imageCell.widthWeight = 20;
+	titleCell.widthWeight = 50;
+	row.height = 60;
+	row.cellSpacing = 10;
+	row.onSelect = () => Safari.open('https://en.wikipedia.org/wiki/Special:Nearby#/coord/'+getCurrentLocation.latitude+','+getCurrentLocation.longitude);
+	row.dismissOnSelect = false;
+	table.addRow(row);
+	label = nextChar(label);
 	return table;
 }
 


### PR DESCRIPTION
When loading the script into Scriptable, it would only allow me to view a location in Boston and would curiously not ask me for location access.

I figured that if I forced to ask for my location by changing the override location from Boston to my current location, I could get it to work.

I am sure this is not the best way to implement it - since it does not cover for the case of people denying location access. But maybe it helps raising attention to the issue and you can fix the script for future users who run into the same issue.

At least it works for me now, and I love it! Great widget :) 